### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/upstream-gtk.yml
+++ b/.github/workflows/upstream-gtk.yml
@@ -1,0 +1,18 @@
+name: Test build with upstream Gtk+
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: dependencies
+      run: sudo apt-get install devscripts equivs && sudo mk-build-deps --install
+    - name: autogen.sh
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --with-maemo-gtk=no --with-examples
+    - name: make
+      run: make -j $(nproc)


### PR DESCRIPTION
This check whether libhildon builds properly with upstream Gtk+. It's complementary to the usual Leste Jenkins integration.

This will prevent from accidentally breaking the build with upstream Gtk+, which was fixed in #5.