### PR TITLE
Don't use maemo-gtk-compat when building with the Maemo Gtk+ API

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libhildon (2.2.26.1-1) unstable; urgency=medium
+
+  * Fix a regression introduced in 2.2.26.
+
+ -- Marcin Mielniczuk <marmistrz.dev@zoho.eu>  Wed, 22 Jan 2020 09:43:35 +0100
+
 libhildon (2.2.26-1) unstable; urgency=medium
 
   * Fix build with upstream Gtk+.

--- a/hildon/Makefile.am
+++ b/hildon/Makefile.am
@@ -26,6 +26,14 @@ libhildon_@API_VERSION_MAJOR@_la_CFLAGS	= \
 		$(X11_LIBS)			\
 		$(CANBERRA_CFLAGS)
 
+if USE_MAEMO_GTK
+SOURCES_COMPAT =
+HEADERS_COMPAT =
+else
+SOURCES_COMPAT = maemo-gtk-compat.c
+HEADERS_COMPAT = maemo-gtk-compat.h
+endif
+
 libhildon_@API_VERSION_MAJOR@_la_SOURCES = \
 		hildon-private.c			\
 		hildon-controlbar.c 			\
@@ -89,7 +97,7 @@ libhildon_@API_VERSION_MAJOR@_la_SOURCES = \
 		hildon-dialog.c				\
 		hildon-main.c				\
 		hildon-live-search.c			\
-		maemo-gtk-compat.c
+		$(SOURCES_COMPAT)
 
 libhildon_@API_VERSION_MAJOR@_built_public_headers  = \
 		hildon-enum-types.h			\
@@ -161,7 +169,7 @@ libhildon_@API_VERSION_MAJOR@_public_headers = \
 		hildon-main.h				\
 		hildon-live-search.h			\
 		hildon-stock.h				\
-		maemo-gtk-compat.h
+		$(HEADERS_COMPAT)
 
 libhildon_@API_VERSION_MAJOR@_include_HEADERS = \
 		$(libhildon_@API_VERSION_MAJOR@_public_headers)		\

--- a/hildon/hildon-gtk.h
+++ b/hildon/hildon-gtk.h
@@ -19,7 +19,9 @@
 
 #include                                        <gtk/gtk.h>
 
+#ifndef MAEMO_GTK
 #include                                        "maemo-gtk-compat.h"
+#endif
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
This will prevent glib-mkenum to produce duplicate definitions of the enums.

Fixes the regression introduced in a5b9dfe71c31058b7f7144bfd557bb178596b586. The reason was that `glib-mkenum` doesn't take the `MAEMO_GTK` define into account.

I checked in the VM that `hildon-enum-types.h` no longer contains any reference to `maemo-gtk-compat.h`.