### PR TITLE
Reduce "Tried to initialized Hildon more than once." from g_critical to g_warning

### DIFF
--- a/hildon/hildon-main.c
+++ b/hildon/hildon-main.c
@@ -100,7 +100,7 @@ hildon_init (void)
   static gboolean initialized = FALSE;
 
   if (initialized) {
-    g_critical ("Tried to initialized Hildon more than once.");
+    g_warning ("Tried to initialized Hildon more than once.");
     return;
   } else {
     initialized = TRUE;


### PR DESCRIPTION
this happening has no negative effect so critical is overdoing it 